### PR TITLE
spices-notifier@germanfr : Additional uuids

### DIFF
--- a/spices-notifier@germanfr/applet.js
+++ b/spices-notifier@germanfr/applet.js
@@ -101,6 +101,7 @@ class SpicesNotifier extends Applet.TextIconApplet {
 		this.settings.bind('username', 'username', this.reload);
 		this.settings.bind('update-interval', 'update_interval', this.reload);
 		this.settings.bind('show-nonzero-only', 'show_nonzero_only', this.update_applet);
+		this.settings.bind('uuidList', 'uuidList', this.reload);
 
 		this.menuManager = new PopupMenu.PopupMenuManager(this);
 		this.menu = new Applet.AppletPopupMenu(this, orientation);
@@ -247,10 +248,13 @@ class SpicesNotifier extends Applet.TextIconApplet {
 	on_xlets_loaded(type, xlets) {
 		let menuItems = [];
 		let username = this.username.toLowerCase();
+		let list = this.uuidList.toLowerCase().split(';');
 
 		for(let uuid in xlets) {
 			let xlet = xlets[uuid];
-			if (xlet.author_user.toLowerCase() === username) {
+			// If the user is the author of the xlet, or the
+			// xlet is in the additional uuids list, add it
+			if (xlet.author_user.toLowerCase() === username || list.indexOf(uuid.toLocaleLowerCase())>=0) {
 				xlet.type = type;
 				xlet.page = `${SPICES_URL}/${type}/view/${xlet['spices-id']}#${HTML_COUNT_ID}`;
 				xlet.uuid = uuid; // Themes don't have UUIDs, use name

--- a/spices-notifier@germanfr/settings-schema.json
+++ b/spices-notifier@germanfr/settings-schema.json
@@ -21,6 +21,13 @@
 		"default": false
 	},
 
+	"uuidList": {
+		"type": "entry",
+		"description": "Additional uuid:s",
+		"tooltip": "Additional uuid:s for applets, desklets, extensions and themes you want to follow (separated by semi-colon).",
+		"default": ""
+	},
+
 	"xlets-cache": {
 		"type": "generic",
 		"default": { "applets": {}, "desklets": {}, "extensions": {}, "themes": {}, "timestamp": 0 }


### PR DESCRIPTION
Adds the possibility for the user to add more uuids for applets, desklets etc that they are not the authors of.